### PR TITLE
Adding explicit repos for jira dependencies

### DIFF
--- a/run.java
+++ b/run.java
@@ -1,4 +1,5 @@
 //usr/bin/env jbang "$0" "$@" ; exit $?
+//REPOS mavencentral,atlassian=https://packages.atlassian.com/maven/repository/public
 //DEPS info.picocli:picocli:4.2.0, com.atlassian.jira:jira-rest-java-client-api:3.0.0, com.atlassian.jira:jira-rest-java-client-core:3.0.0, org.json:json:20200518, com.konghq:unirest-java:3.7.04, com.sun.mail:javax.mail:1.6.2
 
 import com.atlassian.jira.rest.client.api.JiraRestClient;


### PR DESCRIPTION
Jcenter will decommission soon (https://bintray.com/bintray/jcenter).  jira-rest-java-client-api v3.0.0 and jira-rest-java-client-core v3.0.0 artifacts are available only on jcenter and atlassian package repository. Hence adding atlassian package in REPOS for jbang to download the artifacts from